### PR TITLE
Add automatic FFMPEG check + make prompts more clear to follow

### DIFF
--- a/assistant.bat
+++ b/assistant.bat
@@ -9,6 +9,8 @@ echo Checking if FFMPEG is present...
 where /q ffmpeg
 if ERRORLEVEL 1 (
     echo FFMPEG not found! Please install FFMPEG and try again.
+    echo Press any key to exit...
+    pause>nul
     exit /B
 ) else (
     echo FFMPEG found!

--- a/assistant.bat
+++ b/assistant.bat
@@ -18,7 +18,10 @@ if ERRORLEVEL 1 (
 )
 
 :setupmodel
-set /p model="Which model do you Use? "
+echo Models Available:
+echo 3ds
+echo ds
+set /p model="Select a model to convert for (example: 3ds) : "
 if %model%==3ds goto 3dssetup
 if %model%==ds goto setupds
 
@@ -28,11 +31,11 @@ echo mpeg1video
 echo mpeg2video
 echo h263p
 echo libx264
-set /p codec="Which Codec do you want? (example: mpeg1video) "
+set /p codec="Select a codec (example: mpeg1video) : "
 echo Codec Modes Available:
-echo Old Codecs
-echo New Codecs
-set /p mode="Which Codec Mode do you want? (example: new) "
+echo old - Old Codecs
+echo new - New Codecs
+set /p mode="Choose a codec mode (example: new) : "
 if %mode%==new goto newcodec
 if %mode%==old goto oldcodec
 
@@ -41,14 +44,14 @@ echo Sound Codecs Available:
 echo aac - Advanced Audio Coding
 echo mp3 - MPEG Layer 3
 echo %sound% - Copies the Existing Codec 
-set /p sound="Which Sound Codec do you want? (example: aac) "
+set /p sound="Select a sound codec (example: aac) : "
 echo Resolutions Available:
-echo 256x144 - 144p
-echo 426x240 - 240p
-echo 640x360 - 360p
-echo 800x240 - 460p
-echo 854x480 - 480p
-set /p res="Which Resolution do you want? (example: 144p) "
+echo 144p - 256x144
+echo 240p - 426x240
+echo 360p - 640x360
+echo 460p - 800x240
+echo 480p - 854x480
+set /p res="Select a resolution (example: 144p) : "
 if %res%==144p goto vid144
 if %res%==240p goto vid240
 if %res%==360p goto vid360
@@ -60,14 +63,14 @@ echo Sound Codecs Available:
 echo aac - Advanced Audio Coding
 echo mp3 - MPEG Layer 3
 echo %sound% - Copies the Existing Codec 
-set /p sound="Which Sound Codec do you want? (example: aac) "
+set /p sound="Select a sound codec (example: aac) :"
 echo Resolutions Available:
-echo 256x144 - 144p
-echo 426x240 - 240p
-echo 640x360 - 360p
-echo 800x240 - 460p
-echo 854x480 - 480p
-set /p res="Which Resolution do you want? (example: 144p) "
+echo 144p - 256x144
+echo 240p - 426x240
+echo 360p - 640x360
+echo 460p - 800x240
+echo 480p - 854x480
+set /p res="Select a resolution (example: 144p) : "
 if %res%==144p goto vid144n
 if %res%==240p goto vid240n
 if %res%==360p goto vid360n
@@ -82,8 +85,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -103,8 +106,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -124,8 +127,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -145,8 +148,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -166,8 +169,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -187,8 +190,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -208,8 +211,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -229,8 +232,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -250,8 +253,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -271,8 +274,8 @@ echo .mpg
 echo .mp2
 echo .mp3
 echo .mp4
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
 cls
 echo Is this right?
 echo Input: %input%
@@ -286,26 +289,22 @@ pause>nul
 goto 3dssetup
 
 
-
-
 :setupds
 echo Make sure the file is in the same folder as the program
-set /p input="InputFile:(example video.mp4) "
-set /p output="OutputFile:(example output.mp4) "
-goto convertitr
+set /p input="InputFile - (example video.mp4) : "
+set /p output="OutputFile - (example output.mp4) : "
+goto convertitrds
 
 :convertitrds
 echo Is this right?
 echo Input: %input%
 echo Output: %output%
 echo Command: ffmpeg -i %input% -f mp4 -vf "fps=24000/1001, colorspace=space=ycgco:primaries=bt709:trc=bt709:range=pc:iprimaries=bt709:iall=bt709, scale=256:144" -dst_range 1 -color_range 2 -vcodec mpeg4 -profile:v 0 -level 8 -q:v 2 -maxrate 500k -acodec aac -ar 32k -b:a 64000 -ac 1 -slices 1 -g 50 %output%
-echo Press Space to convert
-pause>nul
 goto convertds
 
 :convertds
 ffmpeg -i %input% -f mp4 -vf "fps=24000/1001, colorspace=space=ycgco:primaries=bt709:trc=bt709:range=pc:iprimaries=bt709:iall=bt709, scale=256:144" -dst_range 1 -color_range 2 -vcodec mpeg4 -profile:v 0 -level 8 -q:v 2 -maxrate 500k -acodec aac -ar 32k -b:a 64000 -ac 1 -slices 1 -g 50 %output%
-echo Press Space to convert new file
+echo Press any key to convert another file...
 pause>nul
 goto setupds
 

--- a/assistant.bat
+++ b/assistant.bat
@@ -1,10 +1,21 @@
 @echo off
 cls
 echo VideoPlayer3DS-DS-Assistant
-echo Version 1.0
-echo Press Space for Setup
-pause>nul
-goto setupmodel 
+echo Version 1.x
+goto checkFFMPEG 
+
+:checkFFMPEG
+echo Checking if FFMPEG is present...
+where /q ffmpeg
+if ERRORLEVEL 1 (
+    echo FFMPEG not found! Please install FFMPEG and try again.
+    exit /B
+) else (
+    echo FFMPEG found!
+    echo Press any key to continue...
+    pause>nul
+    goto setupmodel
+)
 
 :setupmodel
 set /p model="Which model do you Use? "
@@ -66,7 +77,6 @@ if %res%==480p goto vid480n
 
 :vid144
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -88,7 +98,6 @@ goto 3dssetup
 
 :vid144n
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -110,7 +119,6 @@ goto 3dssetup
 
 :vid240
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -132,7 +140,6 @@ goto 3dssetup
 
 :vid240n
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -154,7 +161,6 @@ goto 3dssetup
 
 :vid360
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -176,7 +182,6 @@ goto 3dssetup
 
 :vid360n
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -198,7 +203,6 @@ goto 3dssetup
 
 :vid460
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -220,7 +224,6 @@ goto 3dssetup
 
 :vid460n
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -242,7 +245,6 @@ goto 3dssetup
 
 :vid480
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -264,7 +266,6 @@ goto 3dssetup
 
 :vid480n
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 echo Extensions Available:
 echo .mpg
 echo .mp2
@@ -289,7 +290,6 @@ goto 3dssetup
 
 :setupds
 echo Make sure the file is in the same folder as the program
-echo You need FFMPEG installed for this to work!!!
 set /p input="InputFile:(example video.mp4) "
 set /p output="OutputFile:(example output.mp4) "
 goto convertitr


### PR DESCRIPTION
1. Add automatic FFMPEG check :
`:checkFFMPEG` uses `where.exe` to make sure FFMPEG is installed by testing if it can be found in PATH

2. Fix typo in `:setupds` that lead to script exitting

3. Prompts are more clear to what user need to input in